### PR TITLE
Add tag:GetResources permissions to the service role

### DIFF
--- a/tnb-iam-roles/tnb-iam-roles.yaml
+++ b/tnb-iam-roles/tnb-iam-roles.yaml
@@ -198,6 +198,11 @@ Resources:
                   - arn:aws:eks:*:*:nodegroup/tnb*/tnb*/*
                   - arn:aws:cloudformation:*:*:stack/tnb*
                 Sid: "TNBAccessInfraResourcePerms"
+              - Effect: "Allow"
+                Action:
+                    - "tag:GetResources"
+                Resource: "*"
+                Sid: "TaggingPolicy"
 
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy


### PR DESCRIPTION
*Issue #, if available:* AWS TNB service role requires `tag:GetResources` permissions. This is used in most Lifecycle hook script implementations to fetch TNB created resources by tags defined on Tosca nodes.
An example of such usage is here:
- [Tagging the EKS cluster](https://github.com/aws-samples/sample-packages-for-aws-tnb/blob/70cf43ebdcb904cb65890097a488192a98a8027b/Network-Package/nsd.yaml#L307)
- [Using the tag to fetch the cluster in the preCreate lifecycle hook script](https://github.com/aws-samples/sample-packages-for-aws-tnb/blob/70cf43ebdcb904cb65890097a488192a98a8027b/Network-Package/hooks/preCreate.sh#L14).

*Description of changes:* This PR adds the required `tag:GetResources` permission. This matches the exact permissions described in TNB's user guide for [service role policy example](https://docs.aws.amazon.com/tnb/latest/ug/security_iam_id-based-policy-examples.html).

This change was tested in the following manner:
- Created a CFN stack with the `tnb-iam-roles/tnb-iam-roles.yaml` file.
- Instantiated a network instance with the aforementioned network package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
